### PR TITLE
Update to 64-bit Roon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,8 +40,8 @@ sleep 5
 sed -i 's/"ProductName"=.*/"ProductName"="Microsoft Windows 7"/' $HOME/$WIN_ROON_DIR/system.reg
 sed -i 's/"ProductType"=.*/"ProductType"="WinNT"/' $HOME/$WIN_ROON_DIR/system.reg
 
-# install .Net 4.5
-env WINEPREFIX=$PREFIX winetricks -q dotnet45
+# install .Net 4.7
+env WINEPREFIX=$PREFIX winetricks -q dotnet472
 
 sleep 2
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 WIN_ROON_DIR=my_roon_instance
-ROON_DOWNLOAD=http://download.roonlabs.com/builds/RoonInstaller.exe
+ROON_DOWNLOAD=http://download.roonlabs.com/builds/RoonInstaller64.exe
 
 PREFIX="$HOME/$WIN_ROON_DIR"
 
@@ -30,7 +30,7 @@ _check_for_executable wget
 
 # configure Wine
 rm -rf $HOME/$WIN_ROON_DIR
-env WINEPREFIX=$PREFIX WINEARCH=win32 wine wineboot
+env WINEPREFIX=$PREFIX WINEARCH=win64 wine wineboot
 #env WINEPREFIX=$HOME/$WIN_ROON_DIR winecfg
 
 # this is required to make sure the system.reg is settled


### PR DESCRIPTION
Updated to 64-bit Roon

Updated WINE env and Roon to 64-bit.
Solves:
- TIDAL artwork now renders
- full screen on multimonitor no longer uses both monitors when stacked vertically
- seems to be more stable that 32-bit variant which crashed often (on Manjaro 64-bit KDE)

I also tested the update to 64-bit with both .Net 4.5 and 4.72.  Both work, so technically only 8794a29 is required to resolve all of the above issues and fc2f257 is not required.