### PR TITLE
Reduce CPU usage by suppressing Wine warnings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,7 +145,7 @@ cat << _EOF_ > ./start_my_roon_instance.sh
 SCALEFACTOR=1.0
 
 PREFIX=$PREFIX
-env WINEPREFIX=$PREFIX wine ${UNIX_LOCALAPPDATA}${ROONEXE} -scalefactor=\$SCALEFACTOR
+env WINEPREFIX=$PREFIX WINEDEBUG=fixme-all wine ${UNIX_LOCALAPPDATA}${ROONEXE} -scalefactor=\$SCALEFACTOR
 _EOF_
 
 chmod +x ./start_my_roon_instance.sh


### PR DESCRIPTION
This commit addresses an issue observed on Linux Mint 21.1 when running Roon with Wine 8.0. The terminal window gets flooded with warnings like "fixme:manipulation:update_manager_Update", causing CPU utilization to spike to 100%. It is currently unclear if this issue affects other Linux distributions as well.

To improve performance and reduce CPU usage, this fix suppresses the aforementioned warnings. As a result, CPU utilization should return to normal levels, providing a better experience.

Note: This fix is focused on suppressing verbose warning messages that were causing performance issues and does not impact the core functionality of the application or Wine itself.