### PR TITLE
install.sh: use /usr/bin/env bash to support cross platform build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This script makes it possible to run Roon on Wine. It creates a separate Wine instance in a folder; this is required for Roon.
 
-Right now the script is very rudimentary: more stuff is coming soon. Keep in mind that you need the following programs to be installed on your Linux system:
+Right now the script is very rudimentary: more stuff is coming soon. Keep in mind that you need the following programs to be installed on your Linux/FreeBSD system:
 
 * wine
 * winetricks
@@ -37,6 +37,10 @@ This scripts has been reported to work on:
   * Don't use the WineHQ repo, but just the Fedora-native Wine (<code>sudo dnf install wine</code>)
 * Ubuntu
 * Linux Mint
+
+Other OS:
+
+* FreeBSD
 
 <b> Ubuntu 20.04 (Focal Fossa) / Linux Mint 20x requires at least 'winehq-stable' (wine version 7.0+) or 'winehq-staging' (wine version 7.22+) </b>
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #set -x
 WIN_ROON_DIR=my_roon_instance
@@ -140,7 +140,7 @@ ROONEXE="/Roon/Application/Roon.exe"
 # Preconditions for start script met.
 # create start script
 cat << _EOF_ > ./start_my_roon_instance.sh
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This parameter influences the scale at which
 # the Roon UI is rendered.


### PR DESCRIPTION
With the change on shebang,  we are able to build on FreeBSD over wine.
Tested on FreeBSD 15-CURRENT